### PR TITLE
Add missing `%i` format specifier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10.1
+osx_image: xcode10.2
 script:
 - swift test
 - swift build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ## master
 
+- add `%i` to known format specifiers (#12, kudos to @olejnjak)
+- migrate to Swift 5 (#12, kudos to @olejnjak)
+
 ## 0.3.0
 
 - implement positioned arguments (#6, kudos to @fortmarek)

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/yaslab/CSV.swift.git",
         "state": {
           "branch": null,
-          "revision": "032be4276e287c38518eeac38526bbfd9a3060e0",
-          "version": "2.2.1"
+          "revision": "c88aca78506069da753e7b3a68ee532341a9b368",
+          "version": "2.3.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/LocalizationCore/LocRow.swift
+++ b/Sources/LocalizationCore/LocRow.swift
@@ -24,7 +24,7 @@ struct LocRow {
             .replacingOccurrences(of: "%%d", with: "%d")
             .replacingOccurrences(of: "%%s", with: "%s")
             .replacingOccurrences(of: "%%f", with: "%f")
-            .replacingOccurrences(of: "%%i", with: "%d")
+            .replacingOccurrences(of: "%%i", with: "%i")
             .replacingPositionedArgs(separator: " ")
             .replacingPositionedArgs(separator: "\n")
     }

--- a/Sources/LocalizationCore/LocRow.swift
+++ b/Sources/LocalizationCore/LocRow.swift
@@ -24,6 +24,7 @@ struct LocRow {
             .replacingOccurrences(of: "%%d", with: "%d")
             .replacingOccurrences(of: "%%s", with: "%s")
             .replacingOccurrences(of: "%%f", with: "%f")
+            .replacingOccurrences(of: "%%i", with: "%d")
             .replacingPositionedArgs(separator: " ")
             .replacingPositionedArgs(separator: "\n")
     }

--- a/Sources/LocalizationCore/Localization.swift
+++ b/Sources/LocalizationCore/Localization.swift
@@ -31,7 +31,7 @@ public final class Localization {
             let csv = try CSVReader(string: csvString, hasHeaderRow: true, trimFields: true, delimiter: "\t")
             let headerRow = csv.headerRow?.map { langMapping[$0] ?? $0 } ?? []
             
-            guard let locKeyIndex = headerRow.index(of: lockKeyName) else { throw LocalizationError.missingKey(lockKeyName) }
+            guard let locKeyIndex = headerRow.firstIndex(of: lockKeyName) else { throw LocalizationError.missingKey(lockKeyName) }
             
             var values: [String: [LocRow]] = headerRow.filter { langMapping.values.contains($0) }.reduce([:]) { $0 + [$1: []] }
             

--- a/Tests/LocalizationCoreTests/LocRowTests.swift
+++ b/Tests/LocalizationCoreTests/LocRowTests.swift
@@ -14,7 +14,7 @@ final class LocRowTests: XCTestCase {
     
     func testAlternativeIntegerRow() {
         let locRow = LocRow(key: "int_key", value: "int value %i")
-        XCTAssertEqual("\"int_key\" = \"int value %d\";", locRow.localizableRow)
+        XCTAssertEqual("\"int_key\" = \"int value %i\";", locRow.localizableRow)
     }
     
     func testFloatRow() {

--- a/Tests/LocalizationCoreTests/LocRowTests.swift
+++ b/Tests/LocalizationCoreTests/LocRowTests.swift
@@ -12,6 +12,11 @@ final class LocRowTests: XCTestCase {
         XCTAssertEqual("\"int_key\" = \"int value %d\";", locRow.localizableRow)
     }
     
+    func testAlternativeIntegerRow() {
+        let locRow = LocRow(key: "int_key", value: "int value %i")
+        XCTAssertEqual("\"int_key\" = \"int value %d\";", locRow.localizableRow)
+    }
+    
     func testFloatRow() {
         let locRow = LocRow(key: "float_key", value: "float value %f")
         XCTAssertEqual("\"float_key\" = \"float value %f\";", locRow.localizableRow)


### PR DESCRIPTION
When parsing spreadsheet ACKLocalization was escaping `%i` as unknown format specifier, this PR adds it to known specifiers.

Also the project is migrated to Swift 5.

#### Checklist
<!-- DO NOT REMOVE THIS CHECKLIST OR YOU'LL BURN IN HELL 🔥🧨💣 -->
- [x] Updated CHANGELOG.md.
- [x] Added tests (if applicable)
