### PR TITLE
🐛 Fix bad file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@
 
 ## master
 
-## 1.1.0
-
 ### Added
+
+- Fix bad stringsdict file extension ([#17](https://github.com/AckeeCZ/ACKLocalization/pull/17), kudos to @IgorRosocha)
+
+## 1.1.0
 
 - Add support for plural keys ([#16](https://github.com/AckeeCZ/ACKLocalization/pull/16), kudos to @LukasHromadnik)
 
-### 1.0.1
+## 1.0.1
 
 - Add support for specifiying number of decimals for float ([#15](https://github.com/AckeeCZ/ACKLocalization/pull/15), kudos to @fortmarek)
 

--- a/Sources/ACKLocalizationCore/ACKLocalization.swift
+++ b/Sources/ACKLocalizationCore/ACKLocalization.swift
@@ -265,7 +265,7 @@ public final class ACKLocalization {
     
     /// Saves given `mappedValues` to correct directory file
     public func saveMappedValuesPublisher(_ mappedValues: MappedValues, config: Configuration) -> AnyPublisher<Void, LocalizationError> {
-        saveMappedValuesPublisher(mappedValues, directory: config.destinationDir, stringsFileName: config.stringsFileName ?? "Localizable.strings", stringsDictFileName: config.stringsDictFileName ?? "Localizable.stringsDict")
+        saveMappedValuesPublisher(mappedValues, directory: config.destinationDir, stringsFileName: config.stringsFileName ?? "Localizable.strings", stringsDictFileName: config.stringsDictFileName ?? "Localizable.stringsdict")
     }
     
     /// Fetches sheet values from given `config`


### PR DESCRIPTION
We had a bad file extension for with capital `D`. But the correct naming is with the lower one.

#### Checklist
- [x] Added tests (if applicable)
