### PR TITLE
Refactor string literal escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@
 
 ## master
 
-## 1.1.3
-
 ### Fixed
 - Fix creating invalid keys, if contain quote marks ([#22](https://github.com/AckeeCZ/ACKLocalization/pull/22), kudos to @mateuszjablonski)
+
+### Changed
+- Internal refactoring regarding string literal escaping ([#24](https://github.com/AckeeCZ/ACKLocalization/pull/24), kudos to @olejnjak)
 
 ## 1.1.2
 

--- a/Sources/ACKLocalizationCore/Model/LocRow.swift
+++ b/Sources/ACKLocalizationCore/Model/LocRow.swift
@@ -29,16 +29,14 @@ public struct LocRow {
 
     /// Key with replaced quotes
     private var normalizedKey: String {
-        return key
-            .replacingOccurrences(of: "\"", with: "\\\"")
+        key.replacingOccurrences(of: "\"", with: #"\""#)
     }
     
     /// Value with replaced placeholder arguments
     private var normalizedValue: String {
-        return value
-            .replacingOccurrences(of: "\"", with: "\\\"")
-            .replacingOccurrences(of: "\n", with: "\\n")
-            .replacingOccurrences(of: "\\u", with: "\\U")
+        value.replacingOccurrences(of: "\"", with: #"\""#)
+            .replacingOccurrences(of: "\n", with: #"\n"#)
+            .replacingOccurrences(of: "\\u", with: #"\U"#)
             .replacingOccurrences(of: "%s", with: "%@")
             .replacingOccurrences(of: "%", with: "%%")
             .replacingOccurrences(of: "%%@", with: "%@")

--- a/Tests/ACKLocalizationCoreTests/LocRowTests.swift
+++ b/Tests/ACKLocalizationCoreTests/LocRowTests.swift
@@ -4,22 +4,22 @@ import XCTest
 final class LocRowTests: XCTestCase {
     func testBasicRow() {
         let locRow = LocRow(key: "key", value: "value")
-        XCTAssertEqual("\"key\" = \"value\";", locRow.localizableRow)
+        XCTAssertEqual(#""key" = "value";"#, locRow.localizableRow)
     }
     
     func testIntegerRow() {
         let locRow = LocRow(key: "int_key", value: "int value %d")
-        XCTAssertEqual("\"int_key\" = \"int value %d\";", locRow.localizableRow)
+        XCTAssertEqual(#""int_key" = "int value %d";"#, locRow.localizableRow)
     }
     
     func testAlternativeIntegerRow() {
         let locRow = LocRow(key: "int_key", value: "int value %i")
-        XCTAssertEqual("\"int_key\" = \"int value %i\";", locRow.localizableRow)
+        XCTAssertEqual(#""int_key" = "int value %i";"#, locRow.localizableRow)
     }
     
     func testFloatRow() {
         let locRow = LocRow(key: "float_key", value: "float value %f")
-        XCTAssertEqual("\"float_key\" = \"float value %f\";", locRow.localizableRow)
+        XCTAssertEqual(#""float_key" = "float value %f";"#, locRow.localizableRow)
     }
     
     func testOneDecimalFloatRow() {
@@ -34,66 +34,51 @@ final class LocRowTests: XCTestCase {
     
     func testStringRow() {
         let locRow = LocRow(key: "string_key", value: "string value %s")
-        XCTAssertEqual("\"string_key\" = \"string value %@\";", locRow.localizableRow)
+        XCTAssertEqual(#""string_key" = "string value %@";"#, locRow.localizableRow)
     }
     
     func testCocoaStringRow() {
         let locRow = LocRow(key: "string_key", value: "string value %@")
-        XCTAssertEqual("\"string_key\" = \"string value %@\";", locRow.localizableRow)
+        XCTAssertEqual(#""string_key" = "string value %@";"#, locRow.localizableRow)
     }
     
     func testPercentIsEscaped() {
         let locRow = LocRow(key: "percent_key", value: "%d % percent")
-        XCTAssertEqual("\"percent_key\" = \"%d %% percent\";", locRow.localizableRow)
+        XCTAssertEqual(#""percent_key" = "%d %% percent";"#, locRow.localizableRow)
     }
     
     func testKeyQuotesAreEscaped() {
-        let locRow = LocRow(key: "abc\"abc", value: "quotes_value")
-        XCTAssertEqual("\"abc\\\"abc\" = \"quotes_value\";", locRow.localizableRow)
-    }
-    
-    func testKeyQuotesAreEscaped2() {
         let locRow = LocRow(key: "abc\"abc", value: "quotes_value")
         XCTAssertEqual(#""abc\"abc" = "quotes_value";"#, locRow.localizableRow)
     }
     
     func testValueQuotesAreEscaped() {
         let locRow = LocRow(key: "quotes_key", value: "abc\"abc")
-        XCTAssertEqual("\"quotes_key\" = \"abc\\\"abc\";", locRow.localizableRow)
-    }
-    
-    func testValueQuotesAreEscaped2() {
-        let locRow = LocRow(key: "quotes_key", value: "abc\"abc")
         XCTAssertEqual(#""quotes_key" = "abc\"abc";"#, locRow.localizableRow)
     }
     
     func testNewLineIsEscaped() {
-        let locRow = LocRow(key: "nl_key", value: "abc\nabc")
-        XCTAssertEqual("\"nl_key\" = \"abc\\nabc\";", locRow.localizableRow)
-    }
-    
-    func testNewLineIsEscaped2() {
         let locRow = LocRow(key: "nl_key", value: "abc\nabc")
         XCTAssertEqual(#""nl_key" = "abc\nabc";"#, locRow.localizableRow)
     }
     
     func testIntPositionArgumentsAreReplaced() {
         let locRow = LocRow(key: "pos_arg_key", value: "%1$d people will arrive in %2$d minutes")
-        XCTAssertEqual("\"pos_arg_key\" = \"%1$d people will arrive in %2$d minutes\";", locRow.localizableRow)
+        XCTAssertEqual(#""pos_arg_key" = "%1$d people will arrive in %2$d minutes";"#, locRow.localizableRow)
     }
     
     func testFloatPositionArgumentsAreReplaced() {
         let locRow = LocRow(key: "pos_arg_key", value: "%1$f people will arrive in %2$f minutes")
-        XCTAssertEqual("\"pos_arg_key\" = \"%1$f people will arrive in %2$f minutes\";", locRow.localizableRow)
+        XCTAssertEqual(#""pos_arg_key" = "%1$f people will arrive in %2$f minutes";"#, locRow.localizableRow)
     }
     
     func testStringPositionArgumentsAreReplaced() {
         let locRow = LocRow(key: "pos_arg_key", value: "%1$s people will arrive in %2$s minutes")
-        XCTAssertEqual("\"pos_arg_key\" = \"%1$@ people will arrive in %2$@ minutes\";", locRow.localizableRow)
+        XCTAssertEqual(#""pos_arg_key" = "%1$@ people will arrive in %2$@ minutes";"#, locRow.localizableRow)
     }
     
     func testCocoaStringPositionArgumentsAreReplaced() {
         let locRow = LocRow(key: "pos_arg_key", value: "%1$@ people will arrive in %2$@ minutes")
-        XCTAssertEqual("\"pos_arg_key\" = \"%1$@ people will arrive in %2$@ minutes\";", locRow.localizableRow)
+        XCTAssertEqual(#""pos_arg_key" = "%1$@ people will arrive in %2$@ minutes";"#, locRow.localizableRow)
     }
 }

--- a/Tests/ACKLocalizationCoreTests/LocRowTests.swift
+++ b/Tests/ACKLocalizationCoreTests/LocRowTests.swift
@@ -52,14 +52,29 @@ final class LocRowTests: XCTestCase {
         XCTAssertEqual("\"abc\\\"abc\" = \"quotes_value\";", locRow.localizableRow)
     }
     
+    func testKeyQuotesAreEscaped2() {
+        let locRow = LocRow(key: "abc\"abc", value: "quotes_value")
+        XCTAssertEqual(#""abc\"abc" = "quotes_value";"#, locRow.localizableRow)
+    }
+    
     func testValueQuotesAreEscaped() {
         let locRow = LocRow(key: "quotes_key", value: "abc\"abc")
         XCTAssertEqual("\"quotes_key\" = \"abc\\\"abc\";", locRow.localizableRow)
     }
     
+    func testValueQuotesAreEscaped2() {
+        let locRow = LocRow(key: "quotes_key", value: "abc\"abc")
+        XCTAssertEqual(#""quotes_key" = "abc\"abc";"#, locRow.localizableRow)
+    }
+    
     func testNewLineIsEscaped() {
         let locRow = LocRow(key: "nl_key", value: "abc\nabc")
         XCTAssertEqual("\"nl_key\" = \"abc\\nabc\";", locRow.localizableRow)
+    }
+    
+    func testNewLineIsEscaped2() {
+        let locRow = LocRow(key: "nl_key", value: "abc\nabc")
+        XCTAssertEqual(#""nl_key" = "abc\nabc";"#, locRow.localizableRow)
     }
     
     func testIntPositionArgumentsAreReplaced() {


### PR DESCRIPTION
This PR refactors internal escaping sequences so the code is bit more readable.

We should probably discuss if the "added" tests should be present or not, I didn't want to change older tests so we can be sure we do not create any regression, but still wanted to test the new "syntax" as well. I think more tests even if they test the same thing do not hurt.

#### Checklist
- [x] Added tests (if applicable)
