### PR TITLE
🐛 Fix bug in function for removing suffix from string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## master
 
+### Fixed
+
+- Incorrect file name when specified with _.strings_ suffix ([#39](https://github.com/AckeeCZ/ACKLocalization/pull/39), kudos to @vendulasvastal)
+
 ## 1.6.0
 
 ### Added

--- a/Sources/ACKLocalizationCore/ACKLocalization.swift
+++ b/Sources/ACKLocalizationCore/ACKLocalization.swift
@@ -462,8 +462,7 @@ public final class ACKLocalization {
 extension String {
     func removingSuffix(_ suffix: String) -> String {
         guard hasSuffix(suffix) else { return self }
-        
-        return String(self[...index(endIndex, offsetBy: -suffix.count)])
+        return String(dropLast(suffix.count))
     }
 }
 

--- a/Tests/ACKLocalizationCoreTests/ACKLocalizationTests.swift
+++ b/Tests/ACKLocalizationCoreTests/ACKLocalizationTests.swift
@@ -1,4 +1,4 @@
-import ACKLocalizationCore
+@testable import ACKLocalizationCore
 import XCTest
 
 final class ACKLocalizationTests: XCTestCase {
@@ -39,5 +39,10 @@ final class ACKLocalizationTests: XCTestCase {
             LocRow(key: "key_3", value: "value3")
         ]
         XCTAssertNoThrow(try localization.checkDuplicateKeys(form: locRow))
+    }
+
+    func testRemovingSuffix() {
+        var fileName = "Localizable.strings"
+        XCTAssertEqual("Localizable", fileName.removingSuffix(".strings"))
     }
 }


### PR DESCRIPTION
Hi guys 👋

This PR fixes a small bug which would generate `Localization..strings` file instead of `Localization.strings` file when using the following configuration:

```json
{
    "defaultFileName": "Localization.string",
    ....
}
```
The current setup seems to still support default file names with their extension included: https://github.com/AckeeCZ/ACKLocalization/blob/afd8e35a9d52c8f37f488921cf502b141547dd46/Sources/ACKLocalizationCore/ACKLocalization.swift#L206. 

However, it only works properly if no extension is included (`"defaultFileName": "Localization"` as in the example in README). If extension is specified a file with double dot is generated. This is due to the 
`removingSuffix` function only removing `suffix.count-1` last characters of the string instead of `suffix.count` which I think is unexpected.

#### Checklist
- [x] Added tests (if applicable)
